### PR TITLE
Add support for WASM

### DIFF
--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -1,7 +1,30 @@
 #![no_std]
 extern crate libc;
 
+#[cfg(not(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+)))]
 use libc::{c_void, c_char, c_uint, size_t, c_int};
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+))]
+extern crate std;
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+))]
+use std::os::raw::{c_void, c_char, c_uint, c_int};
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+))]
+#[allow(non_camel_case_types)]
+type size_t = usize;
 
 #[derive(Clone, Copy)]
 #[repr(C)]

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -18,8 +18,8 @@
 //! assert_eq!(v, decompress(&comp_wo_prefix, Some(1024)).unwrap());
 //! ```
 
+use super::c_char;
 use super::liblz4::*;
-use libc::c_char;
 use std::io::{Error, ErrorKind, Result};
 
 /// Represents the compression mode do be used.

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,5 +1,5 @@
 use super::liblz4::*;
-use libc::size_t;
+use super::size_t;
 use std::io::{Error, ErrorKind, Read, Result};
 use std::ptr;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,5 +1,5 @@
 use super::liblz4::*;
-use libc::size_t;
+use super::size_t;
 use std::cmp;
 use std::io::Result;
 use std::io::Write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,3 +15,22 @@ pub use crate::liblz4::version;
 pub use crate::liblz4::BlockMode;
 pub use crate::liblz4::BlockSize;
 pub use crate::liblz4::ContentChecksum;
+
+#[cfg(not(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+)))]
+use libc::{c_char, size_t};
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+))]
+use std::os::raw::c_char;
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(any(target_env = "wasi", target_os = "wasi"))
+))]
+#[allow(non_camel_case_types)]
+type size_t = usize;


### PR DESCRIPTION
This adds support for `wasm32-unknown-unknown`. The only changes are defining various C types that `libc` doesn't define for this target.

I would like to have added `cargo build --target wasm32-unknown-unknown` to the CI but unfortunately it's not straightforward and I don't think it's worth doing until there's more clarity around best practises for WASM builds that invoke `$CC`.