### PR TITLE
Support static compilation on Windows in lz4-sys crate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,16 +10,16 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  test:
+  test-nix:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.43.0
+          toolchain: 1.53.0
           override: true
           components: rustfmt
       - name: Checkout
@@ -30,5 +30,37 @@ jobs:
         run: cargo fmt -- --check
       - name: build
         run: cargo build --release
+      - name: unit tests
+        run: cargo test -- --nocapture
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.53.0
+          target: i686-pc-windows-msvc
+          override: true
+          components: rustfmt
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Check Rust formatting
+        run: cargo fmt -- --check
+      - name: build 64-bit
+        run: cargo build --release
+      - name: build 32-bit
+        run: cargo build --release --target i686-pc-windows-msvc
+      - name: build 64-bit static
+        env:
+          CRT_STATIC: "true"
+          RUSTFLAGS: "-C target-feature=+crt-static"
+        run: cargo build --release
+      - name: build 32-bit static
+        env:
+          CRT_STATIC: "true"
+          RUSTFLAGS: "-C target-feature=+crt-static"
+        run: cargo build --release --target i686-pc-windows-msvc
       - name: unit tests
         run: cargo test -- --nocapture

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -29,12 +29,15 @@ fn run() -> Result<(), Box<dyn Error>> {
         if target == "i686-pc-windows-gnu" {
             // Disable auto-vectorization for 32-bit MinGW target.
             compiler.flag("-fno-tree-vectorize");
-        } else if get_from_env("CRT_STATIC")?.to_uppercase() == "TRUE" {
-            // Must supply the /MT compiler flag to use the multi-threaded, static VCRUNTIME library
-            // when building on Windows. Cargo does not pass RUSTFLAGS to build scripts
-            // (see: https://github.com/rust-lang/cargo/issues/4423) so we must use a custom env
-            // variable "CRT_STATIC."
-            compiler.static_crt(true);
+        }
+        if let Ok(value) = get_from_env("CRT_STATIC") {
+            if value.to_uppercase() == "TRUE" {
+                // Must supply the /MT compiler flag to use the multi-threaded, static VCRUNTIME library
+                // when building on Windows. Cargo does not pass RUSTFLAGS to build scripts
+                // (see: https://github.com/rust-lang/cargo/issues/4423) so we must use a custom env
+                // variable "CRT_STATIC."
+                compiler.static_crt(true);
+            }
         }
     }
     compiler.compile("liblz4.a");


### PR DESCRIPTION
The build script for the `lz4-sys` crate does not currently support static compilation on Windows, which requires passing the `/MT` flag.  Unfortunately, cargo does not expose the `RUSTFLAGS` environment variable to build scripts (see: https://github.com/rust-lang/cargo/issues/4423).  This PR adds support for a `CRT_STATIC` environment variable in the build script which triggers adding the `/MT` flag for `msvc` builds only, and updates the CI workflow to test 32 and 64-bit dynamic and static builds on Windows.  I also ran `rustfmt` on the build script which changed some formatting on existing code, but feel free to reject those formatting changes.