### PR TITLE
Add Debug derives

### DIFF
--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -26,19 +26,19 @@ use std::os::raw::{c_void, c_char, c_uint, c_int};
 #[allow(non_camel_case_types)]
 type size_t = usize;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct LZ4FCompressionContext(pub *mut c_void);
 unsafe impl Send for LZ4FCompressionContext {}
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct LZ4FDecompressionContext(pub *mut c_void);
 unsafe impl Send for LZ4FDecompressionContext {}
 
 pub type LZ4FErrorCode = size_t;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[repr(u32)]
 pub enum BlockSize {
     Default = 0, // Default - 64KB
@@ -60,20 +60,21 @@ impl BlockSize {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[repr(u32)]
 pub enum BlockMode {
     Linked = 0,
     Independent,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[repr(u32)]
 pub enum ContentChecksum {
     NoChecksum = 0,
     ChecksumEnabled,
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4FFrameInfo {
     pub block_size_id: BlockSize,
@@ -82,6 +83,7 @@ pub struct LZ4FFrameInfo {
     pub reserved: [c_uint; 5],
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4FPreferences {
     pub frame_info: LZ4FFrameInfo,
@@ -90,6 +92,7 @@ pub struct LZ4FPreferences {
     pub reserved: [c_uint; 4],
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4FCompressOptions {
     pub stable_src: c_uint, /* 1 == src content will remain available on future calls
@@ -98,6 +101,7 @@ pub struct LZ4FCompressOptions {
     pub reserved: [c_uint; 3],
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4FDecompressOptions {
     pub stable_dst: c_uint, /* guarantee that decompressed data will still be there on next
@@ -105,9 +109,11 @@ pub struct LZ4FDecompressOptions {
     pub reserved: [c_uint; 3],
 }
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4StreamEncode(c_void);
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct LZ4StreamDecode(c_void);
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -23,6 +23,7 @@ use super::liblz4::*;
 use std::io::{Error, ErrorKind, Result};
 
 /// Represents the compression mode do be used.
+#[derive(Debug)]
 pub enum CompressionMode {
     /// High compression with compression parameter
     HIGHCOMPRESSION(i32),

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -5,10 +5,12 @@ use std::ptr;
 
 const BUFFER_SIZE: usize = 32 * 1024;
 
+#[derive(Debug)]
 struct DecoderContext {
     c: LZ4FDecompressionContext,
 }
 
+#[derive(Debug)]
 pub struct Decoder<R> {
     c: DecoderContext,
     r: R,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -5,11 +5,12 @@ use std::io::Result;
 use std::io::Write;
 use std::ptr;
 
+#[derive(Debug)]
 struct EncoderContext {
     c: LZ4FCompressionContext,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EncoderBuilder {
     block_size: BlockSize,
     block_mode: BlockMode,
@@ -20,6 +21,7 @@ pub struct EncoderBuilder {
     auto_flush: bool,
 }
 
+#[derive(Debug)]
 pub struct Encoder<W> {
     c: EncoderContext,
     w: W,


### PR DESCRIPTION
I ran into an issue where I couldn't call [into_inner()](https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.into_inner).unwrap() on a `BufWriter<Encoder<File>>` because it needed `Encoder` to be `Debug`. So I've added Debug derive to types without it.