### PR TITLE
Attempt to add content_size.

### DIFF
--- a/lz4-sys/src/lib.rs
+++ b/lz4-sys/src/lib.rs
@@ -5,7 +5,7 @@ extern crate libc;
     target_arch = "wasm32",
     not(any(target_env = "wasi", target_os = "wasi"))
 )))]
-use libc::{c_void, c_char, c_uint, size_t, c_int};
+use libc::{c_void, c_char, c_uint, size_t, c_int, c_ulonglong};
 
 #[cfg(all(
     target_arch = "wasm32",
@@ -80,6 +80,7 @@ pub struct LZ4FFrameInfo {
     pub block_size_id: BlockSize,
     pub block_mode: BlockMode,
     pub content_checksum_flag: ContentChecksum,
+    pub content_size: c_ulonglong,
     pub reserved: [c_uint; 5],
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -20,6 +20,7 @@ pub struct EncoderBuilder {
     // 1 == always flush (reduce need for tmp buffer)
     auto_flush: bool,
     favor_dec_speed: bool,
+    content_size: u64
 }
 
 #[derive(Debug)]
@@ -39,6 +40,7 @@ impl EncoderBuilder {
             level: 0,
             auto_flush: false,
             favor_dec_speed: false,
+            content_size: 0
         }
     }
 
@@ -74,6 +76,11 @@ impl EncoderBuilder {
         self
     }
 
+    pub fn content_size(&mut self, content_size: u64) -> &mut Self {
+        self.content_size = content_size;
+        self
+    }
+
     pub fn build<W: Write>(&self, w: W) -> Result<Encoder<W>> {
         let block_size = self.block_size.get_size();
         let preferences = LZ4FPreferences {
@@ -81,6 +88,7 @@ impl EncoderBuilder {
                 block_size_id: self.block_size.clone(),
                 block_mode: self.block_mode.clone(),
                 content_checksum_flag: self.checksum.clone(),
+                content_size: self.content_size.clone(),
                 reserved: [0; 5],
             },
             compression_level: self.level,


### PR DESCRIPTION
This PR adds the content_size field (which stores the size of the uncompressed data) which is available in the LZ4 definition (https://github.com/lz4/lz4/blob/d44371841a2f1728a3f36839fd4b7e872d0927d3/lib/lz4frame.h#L180), but was not available in lz4-sys or the lz4 library. 

Happy to work with you to tweak this to your standards. Please let me know if there is any way to improve upon this. 