### PR TITLE
Export include directory for header locations.

### DIFF
--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -62,6 +62,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
     }
     println!("cargo:root={}", dst.display());
+    println!("cargo:include={}", include.display());
 
     Ok(())
 }


### PR DESCRIPTION
It seems to be common practice to export the `include` directory (for the location of the header files) when building sys crates, e.g., https://doc.rust-lang.org/cargo/reference/build-script-examples.html#using-another-sys-crate and https://github.com/alexcrichton/bzip2-rs/blob/016e18155ef7c05983ea244cae1344c5b68defd8/bzip2-sys/build.rs#L46.

This PR updates the build script to follow this convention. It's required to unblock the issue for rust-rocksdb vendoring: https://github.com/rust-rocksdb/rust-rocksdb/issues/666

Note: I've done very little testing of this. If there's a way to verify that I haven't screwed anything up, please let me know. More than happy for the maintainers of this crate to pick this PR up too 😄 

Thanks for your help! 😄 