### PR TITLE
Tiny documentation fix on lz4::block::compress_to_buffer

### DIFF
--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -95,7 +95,8 @@ pub fn compress(src: &[u8], mode: Option<CompressionMode>, prepend_size: bool) -
 ///
 /// # Errors
 /// Returns std::io::Error with ErrorKind::InvalidInput if the src buffer is too long.
-/// Returns std::io::Error with ErrorKind::Other if the compression data does not find in `buffer`.
+/// The buffer cannot be larger than `i32::MAX`.
+/// Returns std::io::Error with ErrorKind::Other if the compression data does not fit in `buffer`.
 pub fn compress_to_buffer(
     src: &[u8],
     mode: Option<CompressionMode>,


### PR DESCRIPTION
A couple of small fixes on doc comment of `lz4::block::compress_to_buffer`:
* mentioned maximum buffer length
* fixed a typo