### PR TITLE
Link system liblz4 when available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ lz4-sys = { path = "lz4-sys", version = "1.11.0" }
 
 [dev-dependencies]
 rand = ">=0.7, <=0.8"
+
+[features]
+# Enable this feature if you want to have a statically linked liblz4
+static = ["lz4-sys/static"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,3 @@ lz4-sys = { path = "lz4-sys", version = "1.11.0" }
 
 [dev-dependencies]
 rand = ">=0.7, <=0.8"
-
-[features]
-# Enable this feature if you want to have a statically linked liblz4
-static = ["lz4-sys/static"]

--- a/lz4-sys/Cargo.toml
+++ b/lz4-sys/Cargo.toml
@@ -14,7 +14,3 @@ libc = "0.2"
 [build-dependencies]
 cc = "1.1"
 pkg-config = "0.3.9"
-
-[features]
-# Enable this feature if you want to have a statically linked liblz4
-static = []

--- a/lz4-sys/Cargo.toml
+++ b/lz4-sys/Cargo.toml
@@ -14,3 +14,7 @@ libc = "0.2"
 [build-dependencies]
 cc = "1.1"
 pkg-config = "0.3.9"
+
+[features]
+# Enable this feature if you want to have a statically linked liblz4
+static = []

--- a/lz4-sys/Cargo.toml
+++ b/lz4-sys/Cargo.toml
@@ -13,3 +13,4 @@ libc = "0.2"
 
 [build-dependencies]
 cc = "1.1"
+pkg-config = "0.3.9"

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -15,6 +15,17 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn Error>> {
+    let target = get_from_env("TARGET")?;
+
+    if !target.contains("windows")
+        && pkg_config::Config::new()
+            .cargo_metadata(true)
+            .probe("liblz4")
+            .is_ok()
+    {
+        return Ok(());
+    }
+
     let mut compiler = cc::Build::new();
     compiler
         .file("liblz4/lib/lz4.c")
@@ -24,7 +35,6 @@ fn run() -> Result<(), Box<dyn Error>> {
         // We always compile the C with optimization, because otherwise it is 20x slower.
         .opt_level(3);
 
-    let target = get_from_env("TARGET")?;
     if target.contains("windows") {
         if target == "i686-pc-windows-gnu" {
             // Disable auto-vectorization for 32-bit MinGW target.

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -20,6 +20,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     if !target.contains("windows")
         && !cfg!(feature = "static")
         && pkg_config::Config::new()
+            .print_system_libs(false)
             .cargo_metadata(true)
             .probe("liblz4")
             .is_ok()

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -18,7 +18,6 @@ fn run() -> Result<(), Box<dyn Error>> {
     let target = get_from_env("TARGET")?;
 
     if !target.contains("windows")
-        && !cfg!(feature = "static")
         && pkg_config::Config::new()
             .print_system_libs(false)
             .cargo_metadata(true)

--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -18,6 +18,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let target = get_from_env("TARGET")?;
 
     if !target.contains("windows")
+        && !cfg!(feature = "static")
         && pkg_config::Config::new()
             .cargo_metadata(true)
             .probe("liblz4")


### PR DESCRIPTION
This allows linking an external/system copy of `liblz4` (particularly, a system-wide shared library as preferred or required for Linux distribution packaging), in the same manner as `bzip2-sys`, by imitating:

- https://github.com/alexcrichton/bzip2-rs/pull/58

As noted in https://github.com/alexcrichton/bzip2-rs/pull/58#issuecomment-792684925, some would consider changing the default linking of `liblz4` a breaking change.

This PR is offered with the purpose of packaging the `lz4-sys` and `lz4` crates in Fedora Linux, where bundling is [discouraged, but allowed under certain circumstances](https://docs.fedoraproject.org/en-US/packaging-guidelines/#bundling).

This PR would fix https://github.com/10XGenomics/lz4-rs/issues/36.

Based on [feedback in the Fedora Linux package review](), I dropped the part of this PR that would have added a `static` feature akin to https://github.com/alexcrichton/bzip2-rs/pull/78, but I did so by reverting it rather than force-pushing, so you can still see how it would have worked if you are interested.