### PR TITLE
Add wasm-shim for emscripten target

### DIFF
--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -40,7 +40,9 @@ fn run() -> Result<(), Box<dyn Error>> {
             }
         }
     }
-    let need_wasm_shim = target == "wasm32-unknown-unknown" || target.starts_with("wasm32-wasi");
+    let need_wasm_shim = target == "wasm32-unknown-unknown"
+        || target.starts_with("wasm32-wasi")
+        || target == "wasm32-unknown-emscripten";
 
     if need_wasm_shim {
         println!("cargo:rerun-if-changed=wasm-shim/stdlib.h");


### PR DESCRIPTION
Hi there!

I'm trying to get [cramjam](https://github.com/milesgranger/cramjam) to play nice with wasm32-unknown-emscripten target; after these changes lz4 is happy. Although I wonder if it should be just `target.starts_with("wasm")` check? I don't know that much about wasm stuff though. :sweat_smile: 

Let me know if you want the `test.yaml` workflow updated. (I didn't add it b/c I didn't see the wasi target added)

Related to #49 