### PR TITLE
fix: Propagate `EncoderBuilder`'s setting of `block_checksum`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -99,7 +99,7 @@ impl EncoderBuilder {
                 content_size: self.content_size.clone(),
                 frame_type: FrameType::Frame,
                 dict_id: 0,
-                block_checksum_flag: BlockChecksum::BlockChecksumEnabled,
+                block_checksum_flag: self.block_checksum.clone(),
             },
             compression_level: self.level,
             auto_flush: if self.auto_flush { 1 } else { 0 },


### PR DESCRIPTION
It appears that when `BlockChecksum` was originally introduced, the setting on `EncoderBuilder` never got passed down into `LZ4FPreferences`, resulting in errors like this. In this case, it's Go's [lz4 library](https://github.com/pierrec/lz4) throwing the error:

```
lz4: invalid block checksum: got a1d59126; expected e48f521c
```

I confirmed that applying this patch locally fixes all of the `invalid block checksum` errors. I didn't have time to dig deeper into why this error was happening in the first place -- I would expect it to just result in the block checksum flag being turned on, and correct block checksums to be emitted, but somewhere along the line that appears to not be working correctly. Nevertheless, I believe this change fixes the ability to enable/disable block checksums correctly.