### PR TITLE
explicity on riscv64 march

### DIFF
--- a/lz4-sys/build.rs
+++ b/lz4-sys/build.rs
@@ -25,6 +25,10 @@ fn run() -> Result<(), Box<dyn Error>> {
         .opt_level(3);
 
     let target = get_from_env("TARGET")?;
+    if target.contains("riscv64") {
+        // riscv64 require explict on G/I/E
+        compiler.flag("-march=rv64g");
+    }
     if target.contains("windows") {
         if target == "i686-pc-windows-gnu" {
             // Disable auto-vectorization for 32-bit MinGW target.


### PR DESCRIPTION
Gcc require explicity on ISA subset
```
cargo:warning=gcc: error: '-march=rv64': first ISA subset must be 'e', 'i' or 'g'
```
Ref: https://gitlab.alpinelinux.org/mengzhuo/aports/-/jobs/1630520